### PR TITLE
Provide the correct vendor when logging in

### DIFF
--- a/neato/__init__.py
+++ b/neato/__init__.py
@@ -195,6 +195,7 @@ class NeatoHub:
         """Initialize the Neato hub."""
         self.config = domain_config
         self._neato = neato
+        self._vendor = vendor
         self._hass = hass
 
         self.my_neato = neato(
@@ -210,7 +211,9 @@ class NeatoHub:
         try:
             _LOGGER.debug("Trying to connect to Neato API")
             self.my_neato = self._neato(
-                self.config[CONF_USERNAME], self.config[CONF_PASSWORD])
+                self.config[CONF_USERNAME],
+                self.config[CONF_PASSWORD],
+                self._vendor)
             return True
         except HTTPError:
             _LOGGER.error("Unable to connect to Neato API")


### PR DESCRIPTION
This should fix https://community.home-assistant.io/t/neato-component-add-vendors-in-order-to-allow-support-for-vorwerk-vacuum/121176/20. Again, I haven't tested this. 